### PR TITLE
src: introduce yearly notes page

### DIFF
--- a/src/pdf/lib/links.js
+++ b/src/pdf/lib/links.js
@@ -55,3 +55,7 @@ export function weekRetrospectiveLink( date, config ) {
 export function yearOverviewLink() {
 	return 'year-overview';
 }
+
+export function yearNotesLink() {
+	return 'year-notes';
+}

--- a/src/pdf/pages/year-notes.jsx
+++ b/src/pdf/pages/year-notes.jsx
@@ -1,0 +1,40 @@
+import { Page, StyleSheet, Link } from '@react-pdf/renderer';
+import dayjs from 'dayjs';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { withTranslation } from 'react-i18next';
+
+import PdfConfig from 'pdf/config';
+import { yearOverviewLink, yearNotesLink } from 'pdf/lib/links';
+
+class YearNotesPage extends React.Component {
+	styles = StyleSheet.create( {
+		year: {
+			fontSize: 55,
+			fontWeight: 'bold',
+			textAlign: 'center',
+			color: 'black',
+			textDecoration: 'none',
+			justifyContent: 'center',
+		},
+	} );
+
+	render() {
+		const { config, startDate } = this.props;
+		return (
+			<>
+				<Page id={ yearNotesLink() } size={ config.pageSize }>
+					<Link src={ '#' + yearOverviewLink() } style={ this.styles.year }>{startDate.year()}
+					</Link>
+				</Page>
+			</>
+		);
+	}
+}
+
+YearNotesPage.propTypes = {
+	config: PropTypes.instanceOf( PdfConfig ).isRequired,
+	startDate: PropTypes.instanceOf( dayjs ).isRequired,
+};
+
+export default withTranslation( 'pdf' )( YearNotesPage );

--- a/src/pdf/pages/year-overview.jsx
+++ b/src/pdf/pages/year-overview.jsx
@@ -1,11 +1,11 @@
-import { Page, Text, View, StyleSheet } from '@react-pdf/renderer';
+import { Page, View, Link, StyleSheet } from '@react-pdf/renderer';
 import dayjs from 'dayjs';
 import PropTypes from 'prop-types';
 import React from 'react';
 
 import MiniCalendar, { HIGHLIGHT_NONE } from 'pdf/components/mini-calendar';
 import PdfConfig from 'pdf/config';
-import { yearOverviewLink } from 'pdf/lib/links';
+import { yearOverviewLink, yearNotesLink } from 'pdf/lib/links';
 
 class YearOverviewPage extends React.Component {
 	styles = StyleSheet.create( {
@@ -13,6 +13,9 @@ class YearOverviewPage extends React.Component {
 			fontSize: 55,
 			fontWeight: 'bold',
 			textAlign: 'center',
+			color: 'black',
+			textDecoration: 'none',
+			justifyContent: 'center',
 		},
 		calendars: {
 			flexDirection: 'row',
@@ -46,7 +49,7 @@ class YearOverviewPage extends React.Component {
 		const { config, startDate } = this.props;
 		return (
 			<Page id={ yearOverviewLink() } size={ config.pageSize }>
-				<Text style={ this.styles.year }>{startDate.year()}</Text>
+				<Link src={ '#' + yearNotesLink() } style={ this.styles.year }>{startDate.year()}</Link>
 				<View style={ this.styles.calendars }>{this.renderCalendars()}</View>
 			</Page>
 		);

--- a/src/pdf/recalendar.jsx
+++ b/src/pdf/recalendar.jsx
@@ -9,6 +9,7 @@ import LastPage from 'pdf/pages/last';
 import MonthOverviewPage from 'pdf/pages/month-overview';
 import WeekOverviewPage from 'pdf/pages/week-overview';
 import WeekRetrospectivePage from 'pdf/pages/week-retrospective';
+import YearNotesPage from 'pdf/pages/year-notes';
 import YearOverviewPage from 'pdf/pages/year-overview';
 
 class RecalendarPdf extends React.Component {
@@ -70,6 +71,11 @@ class RecalendarPdf extends React.Component {
 				key={ 'year-overview-' + year }
 				startDate={ currentDate }
 				endDate={ endDate }
+				config={ this.props.config }
+			/>,
+			<YearNotesPage
+				key={ 'year-notes-' + year }
+				startDate={ currentDate }
 				config={ this.props.config }
 			/>,
 		);


### PR DESCRIPTION
Perhaps adding a simple empty notes page might prove as an useful feature. Alternatively, I considered basing the notes page on the Monthly Overview, but it would probably require a new "month list" header subview.

What do you think?