### PR TITLE
Add ics upload support

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
 		"file-saver": "^2.0.5",
 		"i18next": "^22.4.14",
 		"i18next-browser-languagedetector": "^7.0.1",
+		"ical.js": "^1.5.0",
 		"nanoid": "^4.0.2",
 		"pdf-lib": "^1.17.1",
 		"prettier": "^2.8.7",

--- a/src/configuration-form/special-dates.jsx
+++ b/src/configuration-form/special-dates.jsx
@@ -60,31 +60,20 @@ class SpecialDates extends React.Component {
 	};
 
 	onFileLoad = ( event ) => {
-		const jcalData = ICAL.parse( event.target.result );
-		const vcalendar = new ICAL.Component( jcalData );
-		const vevents = vcalendar.getAllSubcomponents( 'vevent' );
-		vevents.forEach( ( vevent ) => {
-			const dtstart = vevent.getFirstPropertyValue( 'dtstart' );
-			const date = dayjs( dtstart.toJSDate() );
-			if ( date.year() !== Number( this.props.year ) ) {
-				return;
-			}
-			const key = date.format( DATE_FORMAT );
-			const value = vevent.getFirstPropertyValue( 'summary' );
-			this.props.onAdd( { date: key, value, type: this.state.icalType } );
-		} );
-	};
-
-	onFileChange = ( event ) => {
-		this.setState( {
-			status: STATUS_LOADING,
-		} );
-
 		try {
-			const file = event.target.files[ 0 ];
-			const reader = new FileReader();
-			reader.onload = this.onFileLoad;
-			reader.readAsText( file );
+			const jcalData = ICAL.parse( event.target.result );
+			const vcalendar = new ICAL.Component( jcalData );
+			const vevents = vcalendar.getAllSubcomponents( 'vevent' );
+			vevents.forEach( ( vevent ) => {
+				const dtstart = vevent.getFirstPropertyValue( 'dtstart' );
+				const date = dayjs( dtstart.toJSDate() );
+				if ( date.year() !== Number( this.props.year ) ) {
+					return;
+				}
+				const key = date.format( DATE_FORMAT );
+				const value = vevent.getFirstPropertyValue( 'summary' );
+				this.props.onAdd( { date: key, value, type: this.state.icalType } );
+			} );
 		} catch ( error ) {
 			this.setState( {
 				status: STATUS_ERROR,
@@ -95,6 +84,18 @@ class SpecialDates extends React.Component {
 		this.setState( {
 			status: STATUS_SUCCESS,
 		} );
+	};
+
+	onFileChange = ( event ) => {
+		this.setState( {
+			status: STATUS_LOADING,
+		} );
+
+		const file = event.target.files[ 0 ];
+		const reader = new FileReader();
+		reader.onload = this.onFileLoad;
+
+		reader.readAsText( file );
 	};
 
 	getGroupedItems() {

--- a/src/configuration.jsx
+++ b/src/configuration.jsx
@@ -314,9 +314,14 @@ class Configuration extends React.PureComponent {
 	};
 
 	handleSpecialDateAdd = ( newSpecialDate ) => {
-		const newSpecialDates = [ ...this.state.specialDates ];
-		newSpecialDates.push( wrapWithId( newSpecialDate ) );
-		this.setState( { specialDates: newSpecialDates } );
+		this.setState(
+			( prev ) => ( {
+				specialDates: [
+					...prev.specialDates,
+					wrapWithId( newSpecialDate ),
+				],
+			} ),
+		);
 	};
 
 	renderFonts() {
@@ -488,6 +493,7 @@ class Configuration extends React.PureComponent {
 						</Accordion.Body>
 					</Accordion.Item>
 					<SpecialDates
+						year={ this.state.year }
 						items={ this.state.specialDates }
 						onAdd={ this.handleSpecialDateAdd }
 						onRemove={ this.handleItemRemove }

--- a/src/locales/en/app.json
+++ b/src/locales/en/app.json
@@ -138,6 +138,12 @@
 			"description": "Add your birthdays, celebrations, events, etc. here to get reminders about them in weekly overviews and day pages as they approach.",
 			"empty": "No dates",
 			"placeholder": "What's the occasion?",
+			"upload": {
+				"label": "Import from .ics file:",
+				"loading": "Reading special dates from ICalendar file, please wait...",
+				"error": "Was not able to load some ICalendar events - try re-exporting the .ics file from your calendar app.",
+				"success": "Special dates loaded from ICalendar file."
+			},
 			"type": {
 				"event": "Event",
 				"holiday": "Holiday"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5209,6 +5209,11 @@ i18next@^22.4.14:
   dependencies:
     "@babel/runtime" "^7.20.6"
 
+ical.js@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/ical.js/-/ical.js-1.5.0.tgz#23213accd1d8f7248d01705acb06270a70d20662"
+  integrity sha512-7ZxMkogUkkaCx810yp0ZGKvq1ZpRgJeornPttpoxe6nYZ3NLesZe1wWMXDdwTkj/b5NtXT+Y16Aakph/ao98ZQ==
+
 iconv-lite@0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"


### PR DESCRIPTION
## Description

Adds support for importing .ics files. May close #23?

- The special dates added are filtered by the year selected in "General options".
- The type can be changed separate from the individual special date control.
- Matches the style and behavior of the config upload.

## Testing Instructions

1. Open "General options"
2. Select a year. (In the demo, I left this as the current year.)
3. Open "Special dates".
4. Select an option from the type dropdown next to the file input. (In the demo, I used "Holiday".)
5. Select "Choose File" and select an .ics file. (In the demo, I'm using [Google's Holidays in United States Calendar](https://calendar.google.com/calendar/ical/en.usa%23holiday%40group.v.calendar.google.com/public/basic.ics).)
6. See that the special dates are added to the list.

## Screenshots

![ReCalendar-ics-import](https://github.com/klimeryk/recalendar.js/assets/5129775/59a960d1-aac6-49bc-a9dc-d58f0b8a0bb5)

https://github.com/klimeryk/recalendar.js/assets/5129775/38e27270-c979-47ee-9f7e-b2068c3061d3
