### PR TITLE
Add date template support to itinerary component

### DIFF
--- a/src/configuration-form/itinerary.jsx
+++ b/src/configuration-form/itinerary.jsx
@@ -17,13 +17,15 @@ import Alert from 'react-bootstrap/Alert';
 import Button from 'react-bootstrap/Button';
 import ButtonGroup from 'react-bootstrap/ButtonGroup';
 import Stack from 'react-bootstrap/Stack';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 
 import SortableItineraryRow from './sortable-itinerary-row';
 
 export const ITINERARY_ITEM = 'item';
 export const ITINERARY_LINES = 'lines';
 export const ITINERARY_NEW_PAGE = 'new_page';
+
+const DATE_FORMATS_URL = 'https://day.js.org/docs/en/display/format#list-of-all-available-formats';
 
 function Itinerary( props ) {
 	const { t } = useTranslation( 'app' );
@@ -60,6 +62,13 @@ function Itinerary( props ) {
 	);
 	return (
 		<>
+			<p><small className="text-muted">
+				<Trans i18nKey="configuration.itinerary.dateTemplate">
+					Include formatted dates using <code>{ '{{date}}' }</code>
+					or <code>{ '{{date:YYYY-MM-DD}}' }</code>.
+					See <a href={ DATE_FORMATS_URL }>available formats</a>.
+				</Trans>
+			</small></p>
 			<Stack gap={ 2 }>
 				<DndContext
 					sensors={ sensors }

--- a/src/locales/en/app.json
+++ b/src/locales/en/app.json
@@ -87,6 +87,7 @@
 		},
 		"itinerary": {
 			"empty": "Empty itinerary",
+			"dateTemplate": "Include formatted dates using <1>{{date}}</1> or <3>{{date:YYYY-MM-DD}}</3>. See <5>available formats</5>.",
 			"placeholder": {
 				"lines": "Number of lines",
 				"page": "New page break",

--- a/src/pdf/components/itinerary.jsx
+++ b/src/pdf/components/itinerary.jsx
@@ -3,6 +3,11 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import { ITINERARY_ITEM, ITINERARY_LINES } from 'configuration-form/itinerary';
+import { DateContext } from 'pdf/lib/DateContext';
+
+// See: https://regex101.com/r/FZ5T35/1
+const DATE_TEMPLATE_REGEX = /{{date(?::([^}]*?))?}}/g;
+const DEFAULT_DATE_FORMAT = 'YYYY-MM-DD';
 
 class Itinerary extends React.PureComponent {
 	styles = StyleSheet.create( {
@@ -28,6 +33,19 @@ class Itinerary extends React.PureComponent {
 	};
 
 	renderItem( text, index ) {
+		const dateTemplateMatches = text.match( DATE_TEMPLATE_REGEX );
+		if ( dateTemplateMatches && dateTemplateMatches.length > 0 ) {
+			return (
+				<DateContext.Consumer>{date => (
+					<Text key={ index } style={ this.styles.line }>
+						{text.replaceAll( DATE_TEMPLATE_REGEX, ( match, format ) => {
+							return date.format( format || DEFAULT_DATE_FORMAT );
+						} )}
+					</Text>
+				)}</DateContext.Consumer>
+			);
+		}
+
 		return (
 			<Text key={ index } style={ this.styles.line }>
 				{text}

--- a/src/pdf/lib/DateContext.js
+++ b/src/pdf/lib/DateContext.js
@@ -1,0 +1,3 @@
+import React from 'react';
+
+export const DateContext = React.createContext();

--- a/src/pdf/pages/day.jsx
+++ b/src/pdf/pages/day.jsx
@@ -11,6 +11,7 @@ import Header from 'pdf/components/header';
 import Itinerary from 'pdf/components/itinerary';
 import MiniCalendar from 'pdf/components/mini-calendar';
 import PdfConfig from 'pdf/config';
+import { DateContext } from 'pdf/lib/DateContext';
 import {
 	dayPageLink,
 	nextDayPageLink,
@@ -46,7 +47,7 @@ class DayPage extends React.Component {
 			findByDate( specialDateKey ),
 		);
 		return (
-			<>
+			<DateContext.Provider value={ date }>
 				<Page id={ dayPageLink( date, config ) } size={ config.pageSize }>
 					<View style={ this.styles.page }>
 						<Header
@@ -66,7 +67,7 @@ class DayPage extends React.Component {
 					</View>
 				</Page>
 				{itemsByPage.slice( 1 ).map( this.renderExtraItems )}
-			</>
+			</DateContext.Provider>
 		);
 	}
 }


### PR DESCRIPTION
This pull request adds support for including formatted dates in the itinerary component. Users can now use the `{{date}}` or `{{date:YYYY-MM-DD}}` template tags to include dates in the itinerary. The available date formats can be found [here](https://day.js.org/docs/en/display/format#list-of-all-available-formats).

Here's a simple example for **adding a date header to a separate itinerary page**:
![adding a date header to a separate itinerary page](https://github.com/klimeryk/recalendar.js/assets/294335/ac23d473-22d0-47cd-bf0c-fa4a7f759d42)


And here's my own setup with **daily one-liners about the year, week and current day**:
![daily one-liners about the year, week and current day](https://github.com/klimeryk/recalendar.js/assets/294335/44249027-5e2e-4c83-8484-033b81ec05d2)
